### PR TITLE
fix: dub episodes returning a sub id despite not having dub episodes

### DIFF
--- a/src/providers/meta/anilist.ts
+++ b/src/providers/meta/anilist.ts
@@ -608,6 +608,14 @@ class Anilist extends AnimeParser {
       } else possibleAnime = await this.findAnimeRaw(slug);
     } else possibleAnime = await this.findAnimeRaw(slug);
 
+    // To avoid a new request, lets match and see if the anime show found is in sub/dub
+
+    let expectedType = dub ? SubOrSub.DUB : SubOrSub.SUB;
+
+    if (possibleAnime.subOrDub != SubOrSub.BOTH && possibleAnime.subOrDub != expectedType) {
+      return [];
+    }
+
     const possibleProviderEpisodes = possibleAnime.episodes;
 
     const options = {

--- a/test/meta/anilist.test.ts
+++ b/test/meta/anilist.test.ts
@@ -16,6 +16,17 @@ test('returns a filled object of anime data', async () => {
   expect(data.description).not.toBeNull();
 });
 
+test('returns episodes for sub and dub not available', async () => {
+  const anilist = new META.Anilist();
+  const subData = await anilist.fetchEpisodesListById('949', false);
+  expect(subData).not.toBeNull();
+  expect(subData).not.toEqual([]);
+
+  const dubData = await anilist.fetchEpisodesListById('949', true);
+  expect(dubData).not.toBeNull();
+  expect(dubData).toEqual([]);
+});
+
 test('returns a filled array of servers', async () => {
   const anilist = new META.Anilist();
   const data = await anilist.fetchEpisodeServers('spy-x-family-episode-9');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix: fixes issues where dub would return on non-dub animes.

**Did you add tests for your changes?**

ye

**If relevant, did you update the documentation?**

no

**Summary**

If no dub episodes found, then return empty array.

**Other information**

hola
