### PR TITLE
Fixes examples in docs

### DIFF
--- a/docs/providers/9anime.md
+++ b/docs/providers/9anime.md
@@ -25,7 +25,7 @@ const nineanime = await ANIME.NineAnime.create();
 ```ts
 nineanime.search("ojisan").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -69,7 +69,7 @@ output:
 ```ts
 nineanime.fetchAnimeInfo("uncle-from-another-world.oj9q8").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IAnimeInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L28-L42)*)\
@@ -127,7 +127,7 @@ In this example, we're getting the sources for the first episode of Overlord IV.
 ```ts
 nineanime.fetchEpisodeSources("155250").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of episode sources. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\
@@ -147,7 +147,7 @@ lol jk. it doesnt work yet :).
 ```ts
 nineanime.fetchEpisodeServers("155250").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of episode servers. (*[`Promise<IEpisodeServer[]>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L54-L57)*)\
 output:

--- a/docs/providers/anilist.md
+++ b/docs/providers/anilist.md
@@ -30,7 +30,7 @@ const anilist = new META.Anilist();
 ```ts
 anilist.search("Classroom of the elite").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -82,7 +82,7 @@ output:
 ```ts
 anilist.fetchTrendingAnime().then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -144,7 +144,7 @@ output:
 ```ts
 anilist.fetchPopularAnime().then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -207,7 +207,7 @@ output:
 ```ts
 anilist.fetchAnimeInfo("98659").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IAnimeInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L28-L42)*)\
@@ -291,7 +291,7 @@ output:
 anilist.fetchAnimeGenres(["Action", "Adventure"])
 .then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
 output:
@@ -337,7 +337,7 @@ output:
 ```ts
 anilist.fetchAiringSchedule(1 , 20, 1660047922, 1661832000, true).then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -406,7 +406,7 @@ In this example, we're getting the sources for the first episode of classroom of
 ```ts
 anilist.fetchEpisodeSources("youkoso-jitsuryoku-shijou-shugi-no-kyoushitsu-e-tv-episode-12").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of episode sources. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\

--- a/docs/providers/animefox.md
+++ b/docs/providers/animefox.md
@@ -22,7 +22,7 @@ const animefox = new ANIME.AnimeFox();
 ```ts
 animefox.fetchRecentEpisodes().then(data => {
   console.log(data);
-}
+})
 ```
 
 
@@ -70,7 +70,7 @@ animefox.fetchRecentEpisodes().then(data => {
 ```ts
 animefox.search("Overlord IV").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -114,7 +114,7 @@ output:
 ```ts
 animefox.fetchAnimeInfo("overlord-iv").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IAnimeInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L28-L42)*)\
@@ -162,7 +162,7 @@ In this example, we're getting the sources for the first episode of Overlord IV.
 ```ts
 animefox.fetchEpisodeSources("overlord-iv").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of episode sources. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\

--- a/docs/providers/animepahe.md
+++ b/docs/providers/animepahe.md
@@ -23,7 +23,7 @@ const animepahe = new ANIME.AnimePahe();
 ```ts
 animepahe.search("Overlord IV").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -66,7 +66,7 @@ output:
 ```ts
 animepahe.fetchAnimeInfo("adb84358-8fec-fe80-1dc5-ad6218421dc1").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IAnimeInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L28-L42)*)\
@@ -111,7 +111,7 @@ In this example, we're getting the sources for the first episode of Overlord IV.
 ```ts
 animepahe.fetchEpisodeSources("c673b4d6cedf5e4cd1900d30d61ee2130e23a74e58f4401a85f21a4e95c94f73").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of episode sources. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\

--- a/docs/providers/animixplay.md
+++ b/docs/providers/animixplay.md
@@ -23,7 +23,7 @@ const animixplay = new ANIME.AniMixPlay();
 ```ts
 animixplay.search("Overlord IV").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -55,7 +55,7 @@ output:
 ```ts
 animixplay.fetchAnimeInfo("/v1/overlord-iv").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IAnimeInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L28-L42)*)\
@@ -97,7 +97,7 @@ In this example, we're getting the sources for the first episode of Overlord IV.
 ```ts
 animixplay.fetchEpisodeSources("MTg4NzY5").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of episode sources. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\

--- a/docs/providers/enime.md
+++ b/docs/providers/enime.md
@@ -25,7 +25,7 @@ const enime = new ANIME.Enime();
 ```ts
 enime.search("Overlord IV").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -76,7 +76,7 @@ output:
 ```ts
 enime.fetchAnimeInfo("cl6k4l2xt000nh4lu54mqankt").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IAnimeInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L28-L42)*)\
@@ -142,7 +142,7 @@ In this example, we're getting the sources for the first episode of Overlord IV.
 ```ts
 enime.fetchEpisodeSources("cl6m9svrt380392sm8x1u89gzh").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of episode sources. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\

--- a/docs/providers/flixhq.md
+++ b/docs/providers/flixhq.md
@@ -25,7 +25,7 @@ const flixhq = new MOVIES.FlixHQ();
 ```ts
 flixhq.search("Vincenzo").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of movies/tv series. (*[`Promise<ISearch<IMovieResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L233-L241)*)\
@@ -59,7 +59,7 @@ output:
 ```ts
 flixhq.fetchMediaInfo("tv/watch-vincenzo-67955").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IMovieInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L243-L254)*)\
@@ -117,7 +117,7 @@ output:
 ```ts
 flixhq.fetchEpisodeSources("1167571", "tv/watch-vincenzo-67955").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of episode sources and subtitles. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\
 output:
@@ -157,7 +157,7 @@ output:
 ```ts
 flixhq.fetchEpisodeServers('1167571', 'tv/watch-vincenzo-67955').then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of episode servers. (*[`Promise<IEpisodeServer[]>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L54-L57)*)\
 output:

--- a/docs/providers/gogoanime.md
+++ b/docs/providers/gogoanime.md
@@ -27,7 +27,7 @@ const gogoanime = new ANIME.Gogoanime();
 ```ts
 gogoanime.search("One Piece").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -71,7 +71,7 @@ output:
 ```ts
 gogoanime.fetchRecentEpisodes().then(data => {
   console.log(data);
-}
+})
 ```
 
 output:
@@ -107,7 +107,7 @@ return top airing anime list.
 ```ts
 gogoanime.fetchTopAiring().then(data => {
   console.log(data);
-}
+})
 ```
 
 output:
@@ -140,7 +140,7 @@ output:
 ```ts
 gogoanime.fetchAnimeInfo("one-piece").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IAnimeInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L28-L42)*)\
@@ -193,7 +193,7 @@ output:
 ```ts
 gogoanime.fetchEpisodeSources("one-piece-episode-1022").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of episode sources. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\
 output:
@@ -226,7 +226,7 @@ output:
 ```ts
 gogoanime.fetchEpisodeServers("one-piece-episode-1022").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of episode servers. (*[`Promise<IEpisodeServer[]>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L54-L57)*)\
 output:

--- a/docs/providers/mangadex.md
+++ b/docs/providers/mangadex.md
@@ -24,7 +24,7 @@ const mangadex = new MANGA.MangaDex();
 ```ts
 mangadex.search("Tomodachi Game").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of manga. (*[`Promise<ISearch<IMangaResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L97-L106)*)\
 output:
@@ -65,7 +65,7 @@ output:
 ```ts
 managdex.fetchMangaInfo("b35f67b6-bfb9-4cbd-86f0-621f37e6cb41").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an manga info object (including the chapters). (*[`Promise<IMangaInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L115-L120)*)\
 output:
@@ -116,7 +116,7 @@ output:
 ```ts
 mangadex.fetchChapterPages("a79255c8-21b5-4a8c-a586-48469fa87020").then(data => {
   console.log(data);
-}
+})
 ```
 returns an array of pages. (*[`Promise<IMangaChapterPage[]>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L122-L126)*)\
 output:

--- a/docs/providers/mangahere.md
+++ b/docs/providers/mangahere.md
@@ -22,7 +22,7 @@ const mangahere = new MANGA.MangaHere();
 ```ts
 mangahere.search("Tomodachi Game").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of manga. (*[`Promise<ISearch<IMangaResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L97-L106)*)\
 output:
@@ -62,7 +62,7 @@ output:
 ```ts
 mangahere.fetchMangaInfo("tomodachi_game").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an manga info object (including the chapters). (*[`Promise<IMangaInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L115-L120)*)\
 output:
@@ -100,7 +100,7 @@ output:
 ```ts
 mangahere.fetchChapterPages("tomodachi_game/c102").then(data => {
   console.log(data);
-}
+})
 ```
 returns an array of pages. (*[`Promise<IMangaChapterPage[]>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L122-L126)*)\
 output:

--- a/docs/providers/mangakakalot.md
+++ b/docs/providers/mangakakalot.md
@@ -22,7 +22,7 @@ const mangakakalot = new MANGA.MangaKakalot();
 ```ts
 mangakakalot.search("Tomodachi Game").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of manga. (*[`Promise<ISearch<IMangaResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L97-L106)*)\
 output:
@@ -58,7 +58,7 @@ output:
 ```ts
 mangakakalot.fetchMangaInfo("manga-kr954974").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an manga info object (including the chapters). (*[`Promise<IMangaInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L115-L120)*)\
 output:
@@ -102,7 +102,7 @@ Note: The `headerForImage` property might be useful when getting the image to di
 ```ts
 mangakakalot.fetchChapterPages("manga-kr954974/chapter-102$$READMANGANATO").then(data => {
   console.log(data);
-}
+})
 ```
 returns an array of pages. (*[`Promise<IMangaChapterPage[]>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L122-L126)*)\
 output:

--- a/docs/providers/mangasee123.md
+++ b/docs/providers/mangasee123.md
@@ -22,7 +22,7 @@ const mangasee123 = new MANGA.Mangasee123();
 ```ts
 mangasee123.search('Call of the Night').then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of manga. (*[`Promise<ISearch<IMangaResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L97-L106)*)\
 output:
@@ -52,7 +52,7 @@ output:
 ```ts
 mangakakalot.fetchMangaInfo('Yofukashi-no-Uta').then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an manga info object (including the chapters). (*[`Promise<IMangaInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L115-L120)*)\
 output:
@@ -91,7 +91,7 @@ Note: The `headerForImage` property might be useful when getting the image to di
 ```ts
 mangakakalot.fetchChapterPages('Yofukashi-no-Uta-chapter-1').then(data => {
   console.log(data);
-}
+})
 ```
 returns an array of pages. (*[`Promise<IMangaChapterPage[]>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L122-L126)*)\
 output:

--- a/docs/providers/readlightnovels.md
+++ b/docs/providers/readlightnovels.md
@@ -22,7 +22,7 @@ const readlightnovels = new LIGHT_NOVELS.ReadLightNovels();
 ```ts
 readlightnovels.search("Classrrom of the Elite").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an array of light novels. (*<a href= "https://github.com/consumet/extensions/blob/master/src/models/types.ts#L128-L134"> <code>Promise<ISearch\<ILightNovelResult>></code></a>*)\
 output:
@@ -53,7 +53,7 @@ output:
 ```ts
 readlightnovels.fetchLightNovelInfo("youkoso-jitsuryoku-shijou-shugi-no-kyoushitsu-e").then(data => {
   console.log(data);
-}
+})
 ```
 returns a promise which resolves into an light novel info object (including the chapters or volumes). (*<a href="https://github.com/consumet/extensions/blob/master/src/models/types.ts#L148-L156"><code>Promise\<ILightNovelInfo></code></a>*)\
 output:
@@ -95,7 +95,7 @@ output:
 ```ts
 readlightnovels.fetchChapterContent("youkoso-jitsuryoku-shijou-shugi-no-kyoushitsu-e/volume-1-prologue-the-structure-of-japanese-society").then(data => {
   console.log(data);
-}
+})
 ```
 returns a content object. (*<a href="https://github.com/consumet/extensions/blob/master/src/models/types.ts#L143-L146"><code>Promise\<ILightNovelChapterContent></code></a>*)\
 output:

--- a/docs/providers/zoro.md
+++ b/docs/providers/zoro.md
@@ -24,7 +24,7 @@ const zoro = new ANIME.Zoro();
 ```ts
 zoro.fetchRecentEpisodes().then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -67,7 +67,7 @@ output:
 ```ts
 zoro.search("Overlord IV").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of anime. (*[`Promise<ISearch<IAnimeResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L13-L26)*)\
@@ -109,7 +109,7 @@ output:
 ```ts
 zoro.fetchAnimeInfo("overlord-iv-18075").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an anime info object (including the episodes). (*[`Promise<IAnimeInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L28-L42)*)\
@@ -155,7 +155,7 @@ In this example, we're getting the sources for the first episode of Overlord IV.
 ```ts
 zoro.fetchEpisodeSources("overlord-iv-18075$episode$92599").then(data => {
   console.log(data);
-}
+})
 ```
 
 returns a promise which resolves into an array of episode sources. (*[`Promise<ISource>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L210-L214)*)\


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
- Fixes code examples used in the docs


**If relevant, did you update the documentation?**
- **Yes**

**Summary**
- In short, all the code examples in the docs were missing a closing parenthesis to end the `.then` statement.



