### PR TITLE
Update mal.ts

### DIFF
--- a/src/providers/meta/mal.ts
+++ b/src/providers/meta/mal.ts
@@ -190,7 +190,7 @@ class Myanimelist extends AnimeParser {
         (this.provider instanceof Zoro || this.provider instanceof Gogoanime) &&
         !dub &&
         (animeInfo.status === MediaStatus.ONGOING ||
-          range({ from: 2000, to: new Date().getFullYear() + 1 }).includes(animeInfo.startDate!.year!))
+          range({ from: 2000, to: new Date().getFullYear() + 1 }).includes(animeInfo.startDate?.year!))
       ) {
         try {
           animeInfo.episodes = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, new provider, refactoring, etc… -->

**Did you add tests for your changes?**
Yes


**Summary**
`{"message":"Cannot read properties of undefined (reading 'year')"}` is thrown in some scenarios when trying to get metadata from MAL. One of those scenarios is: https://api.consumet.org/meta/mal/info/1001

The error is thrown because  the `starteDate` property can be null.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

