### PR TITLE
positive look-behind issue [iOS/Expo]

### DIFF
--- a/src/extractors/kwik.ts
+++ b/src/extractors/kwik.ts
@@ -18,7 +18,7 @@ class Kwik extends VideoExtractor {
 
       const match = load(data)
         .html()
-        .match(/(?<=p}).*(?<=kwik).*}/g);
+        .match(/p\}.*kwik.*/g);
 
       if (!match) {
         throw new Error('Video not found.');
@@ -33,7 +33,11 @@ class Kwik extends VideoExtractor {
 
       const formated = this.format(p, a, c, k, e, {});
 
-      const source = formated.match(/(?<=source=\\).*(?=\\';)/g)[0].replace(/\'/g, '');
+      const source = formated
+        .match(/source=\\(.*?)\\'/g)[0]
+        .replace(/\'/g, '')
+        .replace(/source=/g, '')
+        .replace(/\\/g, '');
 
       this.sources.push({
         url: source,

--- a/src/extractors/rapidcloud.ts
+++ b/src/extractors/rapidcloud.ts
@@ -70,6 +70,8 @@ class RapidCloud extends VideoExtractor {
           const m3u8data = data
             .split('\n')
             .filter((line: string) => line.includes('.m3u8') && line.includes('RESOLUTION='));
+
+          // TODO: Remove positive lookbehind
           const secondHalf = m3u8data.map((line: string) =>
             line.match(/(?<=RESOLUTION=).*(?<=,C)|(?<=URI=).*/g)
           );

--- a/src/providers/anime/animixplay.ts
+++ b/src/providers/anime/animixplay.ts
@@ -86,7 +86,7 @@ class AniMixPlay extends AnimeParser {
 
         for (const key in episodes) {
           animeInfo.episodes.push({
-            id: episodes[key].toString()?.match(/(?<=id=).*(?=&title)/g)[0],
+            id: episodes[key].toString().split('id=')[1].split('&title')[0],
             animixplayId: `${animeInfo.id}/ep${parseInt(key) + 1}`,
             number: parseInt(key) + 1,
             url: `${this.baseUrl}${animeInfo.id}/ep${parseInt(key) + 1}`,
@@ -128,7 +128,7 @@ class AniMixPlay extends AnimeParser {
 //   const animixplay = new AniMixPlay();
 //   const animeInfo = await animixplay.fetchAnimeInfo('/v1/one-piece');
 //   const sources = await animixplay.fetchEpisodeSources(animeInfo.episodes![0].id);
-//   console.log(sources);
+//    console.log(sources);
 // })();
 
 export default AniMixPlay;

--- a/src/providers/anime/zoro.ts
+++ b/src/providers/anime/zoro.ts
@@ -297,7 +297,6 @@ class Zoro extends AnimeParser {
 // (async () => {
 //   const zoro = new Zoro();
 //   const anime = await zoro.search('classroom of the elite');
-//   const episodes = (await zoro.fetchAnimeInfo(anime.results[1].id)).episodes;
 //   const sources = await zoro.fetchEpisodeSources('bleach-the-movie-fade-to-black-1492$episode$58326');
 //   console.log(sources);
 // })();


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix for iOS/Expo when using consumet.ts library on the client side.

Did you add tests for your changes?
No; tested on https://regexr.com/ with multiple cases.

**Summary**
replaced the rest of the positive look-behinds, besides one case in rapid cloud I added a TODO in there to be fixed 

again thank you to @aidanjuma for the help