### PR TITLE
Change default Gogo Server to VidStreaming

### DIFF
--- a/src/providers/anime/gogoanime.ts
+++ b/src/providers/anime/gogoanime.ts
@@ -173,7 +173,7 @@ class Gogoanime extends AnimeParser {
    */
   override fetchEpisodeSources = async (
     episodeId: string,
-    server: StreamingServers = StreamingServers.GogoCDN
+    server: StreamingServers = StreamingServers.VidStreaming
   ): Promise<ISource> => {
     if (episodeId.startsWith('http')) {
       const serverUrl = new URL(episodeId);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This pr changes the default Gogo server from GogoCDN to Vidstreaming to fix mostly all failed video issues.

<!-- E.g. a bugfix, new provider, refactoring, etc… -->

**Did you add tests for your changes?**
N/A
**If relevant, did you update the documentation?**
N/A
**Summary**
N/A
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Other information**
N/A