### PR TITLE
Stop sending errors to the console

### DIFF
--- a/src/providers/anime/gogoanime.ts
+++ b/src/providers/anime/gogoanime.ts
@@ -227,7 +227,6 @@ class Gogoanime extends AnimeParser {
 
       return await this.fetchEpisodeSources(serverUrl.href, server);
     } catch (err) {
-      console.error(err);
       throw new Error('Episode not found.');
     }
   };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This pull request fixes gogo anime's fetchEpisodeSources function logging errors to the console.

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

N/A

**Summary**

I am not sure if that line is deliberately there, but it is extremely annoying to get errors in the console when I am catching errors thrown from the function.

**Other information**

N/A