### PR TITLE
fix: AnimePahe `fetchAnimeInfo` method

### DIFF
--- a/src/providers/anime/animepahe.ts
+++ b/src/providers/anime/animepahe.ts
@@ -81,7 +81,7 @@ class AnimePahe extends AnimeParser {
         .map((i, el) => $(el).find('a').attr('title'))
         .get();
 
-      switch ($('div.col-sm-4.anime-info > p:nth-child(4) > a').text().trim()) {
+      switch ($('div.col-sm-4.anime-info > p:nth-child(5) > strong > a').text().trim()) {
         case 'Currently Airing':
           animeInfo.status = MediaStatus.ONGOING;
           break;
@@ -91,27 +91,30 @@ class AnimePahe extends AnimeParser {
         default:
           animeInfo.status = MediaStatus.UNKNOWN;
       }
-      animeInfo.type = $('div.col-sm-4.anime-info > p:nth-child(2) > a')
+      animeInfo.type = $('div.col-sm-4.anime-info > p:nth-child(3) > strong > a')
         .text()
         .trim()
         .toUpperCase() as MediaFormat;
-      animeInfo.releaseDate = $('div.col-sm-4.anime-info > p:nth-child(5)')
+      animeInfo.releaseDate = $('div.col-sm-4.anime-info > p:nth-child(7)')
         .text()
         .split('to')[0]
         .replace('Aired:', '')
         .trim();
-      animeInfo.aired = $('div.col-sm-4.anime-info > p:nth-child(5)')
+      animeInfo.aired = $('div.col-sm-4.anime-info > p:nth-child(7)')
         .text()
         .replace('Aired:', '')
         .trim()
         .replace('\n', ' ');
-      animeInfo.studios = $('div.col-sm-4.anime-info > p:nth-child(7)')
+      animeInfo.studios = $('div.col-sm-4.anime-info > p:nth-child(9)')
         .text()
         .replace('Studio:', '')
         .trim()
         .split('\n');
       animeInfo.totalEpisodes = parseInt(
-        $('div.col-sm-4.anime-info > p:nth-child(3)').text().replace('Episodes:', '')
+        $('div.col-sm-4.anime-info > p:nth-child(3)')
+          .text()
+          .replace('Episode:', '')
+          .replace('Episodes:', '')
       );
 
       animeInfo.episodes = [];

--- a/src/providers/anime/animepahe.ts
+++ b/src/providers/anime/animepahe.ts
@@ -111,7 +111,7 @@ class AnimePahe extends AnimeParser {
         .trim()
         .split('\n');
       animeInfo.totalEpisodes = parseInt(
-        $('div.col-sm-4.anime-info > p:nth-child(3)')
+        $('div.col-sm-4.anime-info > p:nth-child(4)')
           .text()
           .replace('Episode:', '')
           .replace('Episodes:', '')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- bugfix

**Did you add tests for your changes?**

- no

**If relevant, did you update the documentation?**

- no

**Summary**

- Update AnimePahe provider `fetchAnimeInfo` method, because it provided broken info.
- I don't know the correct way to do:

```
totalEpisodes = $('el').replace('Episode:', '').replace('Episodes:', '')
```

But when you try to collect info on a title with only 1 episode (movie, or special/ova), you get `null` - I tested it on [Steins;Gate: Open the Missing Link - Divide By Zero](https://animepahe.ru/anime/116f6cd9-d01e-1025-200b-b09330bb97a4)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Other information**

Not a native speaker, excuse my grammar