### PR TITLE
Zoro fix

### DIFF
--- a/src/models/base-parser.ts
+++ b/src/models/base-parser.ts
@@ -22,7 +22,7 @@ abstract class BaseParser extends BaseProvider {
           ...config.headers,
           'x-api-key': proxy?.key ?? '',
         };
-        config.url = `${proxy.url}${config?.baseURL}${config?.url ? config?.url : ''}}`;
+        config.url = `${proxy.url}${config?.baseURL}${config?.url ? config?.url : ''}`;
       }
       return config;
     });

--- a/src/providers/anime/zoro.ts
+++ b/src/providers/anime/zoro.ts
@@ -25,7 +25,7 @@ class Zoro extends AnimeParser {
     'https://is3-ssl.mzstatic.com/image/thumb/Purple112/v4/7e/91/00/7e9100ee-2b62-0942-4cdc-e9b93252ce1c/source/512x512bb.jpg';
   protected override classPath = 'ANIME.Zoro';
 
-  constructor(zoroBase : string | undefined){
+  constructor(zoroBase? : string){
     super();
     this.baseUrl = zoroBase ? zoroBase : this.baseUrl;
   }

--- a/src/providers/anime/zoro.ts
+++ b/src/providers/anime/zoro.ts
@@ -25,6 +25,10 @@ class Zoro extends AnimeParser {
     'https://is3-ssl.mzstatic.com/image/thumb/Purple112/v4/7e/91/00/7e9100ee-2b62-0942-4cdc-e9b93252ce1c/source/512x512bb.jpg';
   protected override classPath = 'ANIME.Zoro';
 
+  constructor(zoroBase : string | undefined){
+    super();
+    this.baseUrl = zoroBase ? zoroBase : this.baseUrl;
+  }
   /**
    * @param query Search query
    * @param page Page number (optional)


### PR DESCRIPTION
Makes it so zoro's base URL can be changed by modifying api.consumet.org's `.env` file.
Also removes the extra bracket from `base-parser.ts`