### PR TITLE
fix (zoro): hasNextPage returning true, when it's false

### DIFF
--- a/src/providers/anime/zoro.ts
+++ b/src/providers/anime/zoro.ts
@@ -25,7 +25,7 @@ class Zoro extends AnimeParser {
     'https://is3-ssl.mzstatic.com/image/thumb/Purple112/v4/7e/91/00/7e9100ee-2b62-0942-4cdc-e9b93252ce1c/source/512x512bb.jpg';
   protected override classPath = 'ANIME.Zoro';
 
-  constructor(zoroBase? : string){
+  constructor(zoroBase?: string) {
     super();
     this.baseUrl = zoroBase ? zoroBase : this.baseUrl;
   }
@@ -47,11 +47,11 @@ class Zoro extends AnimeParser {
       const $ = load(data);
 
       res.hasNextPage =
-        $('.pagination > li').length > 0
-          ? $('.pagination > li').last().hasClass('active')
-            ? false
-            : true
-          : false;
+        $('.pagination > li').length > 0 ?
+          $('.pagination li.active').length > 0 ?
+            $('.pagination > li').last().hasClass('active') ? false : true
+          : false
+        : false;
 
       $('.film_list-wrap > div.flw-item').each((i, el) => {
         const id = $(el)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixed a bug where, when searching for a keyword with an exceded page limit sets hasNextPage to be true, where it should be false.

For example: 
![image](https://user-images.githubusercontent.com/101876769/217756891-31a091f4-6b2a-4863-8763-e13ed3f67f6a.png)

In this example, I am searching for the keyword a, I did a little digging and found that the max page limit for the keyword "a" is 49. So the page limit 50 should show that hasNextPage is false.

