### PR TITLE
feat: adding MangaHost manga provider

### DIFF
--- a/docs/guides/manga.md
+++ b/docs/guides/manga.md
@@ -18,7 +18,7 @@ const mangaProvider = MANGA.<providerName>();
 
 ``isNSFW`` - bool, ``true`` if the provider providers NSFW content.
 
-``isWorking`` - bool, a bool to identify the state of the current provider, ``true`` if the provider is working, ``false`` otherwise. 
+``isWorking`` - bool, a bool to identify the state of the current provider, ``true`` if the provider is working, ``false`` otherwise.
 
 ``name`` - string, the name of the current provider, example: ``name: 'Crunchyroll'``
 
@@ -36,6 +36,7 @@ This list is in alphabetical order. (except the sub bullet points)
 - [MangaHere](../providers/mangahere.md)
 - [MangaKakalot](../providers/mangakakalot.md)
 - [Mangasee123](../providers/mangasee123.md)
+- [MangaHost](../providers/mangahost.md)
 
 
 <p align="end">(<a href="https://github.com/consumet/extensions/blob/master/docs">back to table of contents</a>)</p>

--- a/docs/providers/mangahost.md
+++ b/docs/providers/mangahost.md
@@ -1,0 +1,124 @@
+<h1> MangaHost 🇧🇷 </h1>
+
+```ts
+const mangahost = new MANGA.MangaHost();
+```
+
+<h2>Methods</h2>
+
+- [search](#search)
+- [fetchMangaInfo](#fetchmangainfo)
+- [fetchChapterPages](#fetchchapterpages)
+
+### search
+> Note: This method is a subclass of the [`BaseParser`](https://github.com/consumet/extensions/blob/master/src/models/base-parser.ts) class. meaning it is available across most categories.
+>
+<h4>Parameters</h4>
+
+| Parameter | Type     | Description                                                                  |
+| --------- | -------- | ---------------------------------------------------------------------------- |
+| query     | `string` | query to search for. (*In this case, We're searching for `punpun`*) |
+
+```ts
+mangahost.search("punpun").then(data => {
+  console.log(data);
+})
+```
+returns a promise which resolves into an array of manga. (*[`Promise<ISearch<IMangaResult[]>>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L97-L106)*)\
+output:
+```js
+{
+  results: [
+      {
+        id: 'oyasumi-punpun-mh34076',
+        title: 'Oyasumi Punpun',
+        image: 'https://img-host.filestatic3.xyz/mangas_files/oyasumi-punpun/image_oyasumi-punpun_xmedium.jpg',
+        headerForImage: { Referer: 'https://mangahosted.com' }
+      }
+    ]
+}
+```
+
+### fetchMangaInfo
+
+<h4>Parameters</h4>
+
+| Parameter | Type     | Description                                                    |
+| --------- | -------- | -------------------------------------------------------------- |
+| mangaId   | `string` | manga id.(*manga id can be found in the manga search results*) |
+
+```ts
+mangahost.fetchMangaInfo("oyasumi-punpun-mh34076").then(data => {
+  console.log(data);
+})
+```
+returns a promise which resolves into an manga info object (including the chapters). (*[`Promise<IMangaInfo>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L115-L120)*)\
+output:
+```js
+{
+      id: 'oyasumi-punpun-mh34076',
+      title: 'Oyasumi Punpun',
+      altTitles: 'おやすみプンプンCompleto',
+      description: 'Punpun é uma criança como todas as outras. Alegre e hiperativo, ele passa por muitos conflitos em sua vida, assim como qualquer outro ser humano. Essa é a história sobre a vida de Punpun, superando seus obstáculos e as adversidades que o mundo lhe traz.',
+      headerForImage: { Referer: 'https://mangahosted.com' },
+      image: 'https://img-host.filestatic3.xyz/mangas_files/oyasumi-punpun/image_oyasumi-punpun_full.jpg',
+      genres: [
+        'adulto',
+        'comedia',
+        'drama',
+        'escolar',
+        'psicologico',
+        'seinen',
+        'slice of life'
+      ],
+      status: 'Completed',
+      views: 55498,
+      authors: [ 'Asano Inio' ],
+      chapters: [
+        {
+          id: '147',
+          title: 'Capítulo #147 - Oyasumi Punpun',
+          views: null,
+          releasedDate: ''
+        },
+        {...}
+      ]
+    }
+```
+Note: The `headerForImage` property might be useful when getting the image to display.
+
+### fetchChapterPages
+
+<h4>Parameters</h4>
+
+| Parameter | Type     | Description                                              |
+| --------- | -------- | -------------------------------------------------------- |
+| mangaId | `string` | manga id.(*chapter id is the same one from the fetchMangaInfo function*) |
+| chapterId | `string` | chapter id.(*chapter id can be found in the manga info*) |
+
+```ts
+mangahost.fetchChapterPages("oyasumi-punpun-mh34076/1").then(data => {
+  console.log(data);
+})
+```
+returns an array of pages. (*[`Promise<IMangaChapterPage[]>`](https://github.com/consumet/extensions/blob/master/src/models/types.ts#L122-L126)*)\
+output:
+```js
+[
+  {
+      img: 'https://img-host.filestatic3.xyz/mangas_files/oyasumi-punpun/1/00.png',
+      page: 0,
+      title: 'Page 1',
+      headerForImage: { Referer: 'https://mangahosted.com' }
+  },
+  {
+      img: 'https://img-host.filestatic3.xyz/mangas_files/oyasumi-punpun/1/01-02.jpg',
+      page: 1,
+      title: 'Page 2',
+      headerForImage: { Referer: 'https://mangahosted.com' }
+  },
+  {...}
+]
+```
+
+<p align="end">(<a href="https://github.com/consumet/extensions/blob/master/docs/guides/manga.md#">back to manga providers list</a>)</p>

--- a/src/providers/manga/index.ts
+++ b/src/providers/manga/index.ts
@@ -8,5 +8,18 @@ import MangaPill from './mangapill';
 import MangaReader from './mangareader';
 import AsuraScans from './asurascans';
 import FlameScans from './flamescans';
+import MangaHost from './mangahost';
 
-export default { MangaDex, ComicK, MangaHere, MangaKakalot, Mangasee123, Mangapark, MangaPill, MangaReader, AsuraScans, FlameScans };
+export default {
+  MangaDex,
+  ComicK,
+  MangaHere,
+  MangaKakalot,
+  Mangasee123,
+  Mangapark,
+  MangaPill,
+  MangaReader,
+  AsuraScans,
+  FlameScans,
+  MangaHost,
+};

--- a/src/providers/manga/mangahost.ts
+++ b/src/providers/manga/mangahost.ts
@@ -62,7 +62,7 @@ class MangaHost extends MangaParser {
             .match(/Adicionado em (.+?)"/);
 
           return {
-            id: `/${$(el).find('a.btn-caps').text()}`,
+            id: `${$(el).find('a.btn-caps').text()}`,
             title: $(el).find('a.btn-caps').attr('title')!,
             views: null,
             releasedDate: releasedDate ? releasedDate[1] : '',
@@ -82,7 +82,7 @@ class MangaHost extends MangaParser {
       const { data } = await axios.get(url);
       const $ = load(data);
 
-      const pages = $('section#imageWrapper > div > div.read-slideshow > a > picture > img')
+      const pages = $('section#imageWrapper > div > div.read-slideshow > a > img')
         .map(
           (i, el): IMangaChapterPage => ({
             img: $(el).attr('src')!,

--- a/src/providers/manga/mangahost.ts
+++ b/src/providers/manga/mangahost.ts
@@ -1,0 +1,130 @@
+import axios from 'axios';
+import { load } from 'cheerio';
+
+import {
+  MangaParser,
+  ISearch,
+  IMangaInfo,
+  IMangaResult,
+  MediaStatus,
+  IMangaChapterPage,
+  IMangaChapter,
+} from '../../models';
+
+class MangaHost extends MangaParser {
+  override readonly name = 'MangaHost';
+  protected override baseUrl = 'https://mangahosted.com';
+  protected override logo = 'https://i.imgur.com/OVlhhsR.png';
+  protected override classPath = 'MANGA.MangaHost';
+
+  override fetchMangaInfo = async (mangaId: string): Promise<IMangaInfo> => {
+    const mangaInfo: IMangaInfo = {
+      id: mangaId,
+      title: '',
+    };
+    try {
+      const { data } = await axios.get(`${this.baseUrl}/manga/${mangaId}`);
+      const $ = load(data);
+
+      mangaInfo.title = $('article.ejeCg > h1.title').text();
+      mangaInfo.altTitles = $('article.ejeCg > h3.subtitle').text();
+      mangaInfo.description = $('div.text > div.paragraph > p').text().replace(/\n/g, '').trim();
+      mangaInfo.headerForImage = { Referer: this.baseUrl };
+      mangaInfo.image = $('div.widget:nth-child(1) > picture > img').attr('src');
+      mangaInfo.genres = $('article.ejeCg:nth-child(1) > div.tags > a.tag ')
+        .map((i, el) => $(el).text())
+        .get();
+
+      switch ($('h3.subtitle > strong').text()) {
+        case 'Completo':
+          mangaInfo.status = MediaStatus.COMPLETED;
+          break;
+        case 'Ativo':
+          mangaInfo.status = MediaStatus.ONGOING;
+          break;
+        default:
+          mangaInfo.status = MediaStatus.UNKNOWN;
+      }
+      mangaInfo.views = parseInt(
+        $('div.classificacao-box-1 > div.text-block-3').text().replace(' views', '').replace(/,/g, '').trim()
+      );
+      mangaInfo.authors = $(
+        'div.w-col.w-col-6:nth-child(1) > ul.w-list-unstyled:nth-child(1) > li:nth-child(3) > div:nth-child(1)'
+      )
+        .map((i, el) => $(el).text().replace('Autor: ', '').trim())
+        .get();
+
+      mangaInfo.chapters = $('div.chapters > div.cap')
+        .map((i, el): IMangaChapter => {
+          const releasedDate = $(el)
+            .find('div.card > div.pop-content > small')
+            .text()
+            .match(/Adicionado em (.+?)"/);
+
+          return {
+            id: `/${$(el).find('a.btn-caps').text()}`,
+            title: $(el).find('a.btn-caps').attr('title')!,
+            views: null,
+            releasedDate: releasedDate ? releasedDate[1] : '',
+          };
+        })
+        .get();
+
+      return mangaInfo;
+    } catch (err) {
+      throw new Error((err as Error).message);
+    }
+  };
+
+  override fetchChapterPages = async (mangaId: string, chapterId: string): Promise<IMangaChapterPage[]> => {
+    try {
+      const url = `${this.baseUrl}/manga/${mangaId}/${chapterId}`;
+      const { data } = await axios.get(url);
+      const $ = load(data);
+
+      const pages = $('section#imageWrapper > div > div.read-slideshow > a > picture > img')
+        .map(
+          (i, el): IMangaChapterPage => ({
+            img: $(el).attr('src')!,
+            page: i,
+            title: `Page ${i + 1}`,
+            headerForImage: { Referer: this.baseUrl },
+          })
+        )
+        .get();
+
+      return pages;
+    } catch (err) {
+      throw new Error((err as Error).message);
+    }
+  };
+
+  /**
+   *
+   * @param query Search query
+   */
+  override search = async (query: string): Promise<ISearch<IMangaResult>> => {
+    try {
+      const { data } = await axios.get(`${this.baseUrl}/find/${query.replace(/ /g, '+')}`);
+      const $ = load(data);
+
+      const results = $('body > div.w-container > main > table > tbody > tr')
+        .map(
+          (i, row): IMangaResult => ({
+            id: $(row).find('td > a.pull-left').attr('href')?.split('/')[4]!,
+            title: $(row).find('td > h4.entry-title > a').text(),
+            image: $(row).find('td > a.pull-left > picture > img.manga').attr('src'),
+            headerForImage: { Referer: this.baseUrl },
+          })
+        )
+        .get();
+      return {
+        results: results,
+      };
+    } catch (err) {
+      throw new Error((err as Error).message);
+    }
+  };
+}
+
+export default MangaHost;

--- a/test/manga/mangahost.test.ts
+++ b/test/manga/mangahost.test.ts
@@ -6,5 +6,13 @@ const mangahost = new MANGA.MangaHost();
 
 test('returns a filled array of manga', async () => {
   const data = await mangahost.search('punpun');
+  console.log(data.results);
+
+  const manga = await mangahost.fetchMangaInfo('oyasumi-punpun-mh34076');
+  console.log(manga);
+
+  const chapterImages = await mangahost.fetchChapterPages('oyasumi-punpun-mh34076', '1');
+  console.log(chapterImages);
+
   expect(data.results).not.toEqual([]);
 });

--- a/test/manga/mangahost.test.ts
+++ b/test/manga/mangahost.test.ts
@@ -1,0 +1,10 @@
+import { MANGA } from '../../src/providers';
+
+jest.setTimeout(120000);
+
+const mangahost = new MANGA.MangaHost();
+
+test('returns a filled array of manga', async () => {
+  const data = await mangahost.search('punpun');
+  expect(data.results).not.toEqual([]);
+});

--- a/test/manga/mangahost.test.ts
+++ b/test/manga/mangahost.test.ts
@@ -6,13 +6,6 @@ const mangahost = new MANGA.MangaHost();
 
 test('returns a filled array of manga', async () => {
   const data = await mangahost.search('punpun');
-  console.log(data.results);
-
-  const manga = await mangahost.fetchMangaInfo('oyasumi-punpun-mh34076');
-  console.log(manga);
-
-  const chapterImages = await mangahost.fetchChapterPages('oyasumi-punpun-mh34076', '1');
-  console.log(chapterImages);
 
   expect(data.results).not.toEqual([]);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
- Adds a new manga provider.

<!-- E.g. a bugfix, new provider, refactoring, etc… -->

**Did you add tests for your changes?**
- Yes, just a basic one but if needed I can add more.

**If relevant, did you update the documentation?**

- Yes.

**Summary**
- Adds a new Manga provider called MangaHost (provides brazilian-portuguese scans 🇧🇷)
- Added search, fetchMangaInfo and fetchChapterImages functions.
```ts
mangahost.search("punpun").then(data => {
  console.log(data);
})

mangahost.fetchMangaInfo("oyasumi-punpun-mh34076").then(data => {
  console.log(data);
})

mangahost.fetchChapterPages("oyasumi-punpun-mh34076/1").then(data => {
  console.log(data);
})
```
- Added test.
- Updated docs with example usage.

**Other information**
I added this provider because I'm currently working on a manga reading app and would love to have a brazilian portuguese option for my brazilian friends. Since the library didn't provide any, I added it myself :) 