### PR TITLE
fix(rapidcloud): include intro if available

### DIFF
--- a/src/extractors/rapidcloud.ts
+++ b/src/extractors/rapidcloud.ts
@@ -69,18 +69,18 @@ class RapidCloud extends VideoExtractor {
 
       try {
         if (encrypted) {
-          const sourcesArray = sources.split("");
-          let extractedKey = "";
+          const sourcesArray = sources.split('');
+          let extractedKey = '';
 
           for (const index of decryptKey) {
             for (let i = index[0]; i < index[1]; i++) {
               extractedKey += sources[i];
-              sourcesArray[i] = "";
+              sourcesArray[i] = '';
             }
           }
 
           decryptKey = extractedKey;
-          sources = sourcesArray.join("");
+          sources = sourcesArray.join('');
 
           const decrypt = CryptoJS.AES.decrypt(sources, decryptKey);
           sources = JSON.parse(decrypt.toString(CryptoJS.enc.Utf8));
@@ -123,12 +123,13 @@ class RapidCloud extends VideoExtractor {
           }
           result.sources.push(...this.sources);
         }
-        if (intro.end > 1) {
-          result.intro = {
-            start: intro.start,
-            end: intro.end,
-          };
-        }
+      }
+
+      if (intro?.end > 1) {
+        result.intro = {
+          start: intro.start,
+          end: intro.end,
+        };
       }
 
       result.sources.push({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixes an issue where intro information would be omitted from the response even though it was available. 


**Summary**
When using the zoro provider intro information was no longer being provided. The information was currently only being added if the host included _rapid-cloud.co_. This fix ensures that the information is included in the response when available. I believe this was also mentioned in #368. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

