### PR TITLE
fix(gogoanime): fix invalid id in info response

### DIFF
--- a/src/providers/anime/gogoanime.ts
+++ b/src/providers/anime/gogoanime.ts
@@ -76,7 +76,7 @@ class Gogoanime extends AnimeParser {
     const animeInfo: IAnimeInfo = {
       id: '',
       title: '',
-      url: `${this.baseUrl}${id}`,
+      url: '',
       genres: [],
       totalEpisodes: 0,
     };
@@ -85,7 +85,7 @@ class Gogoanime extends AnimeParser {
 
       const $ = load(res.data);
 
-      animeInfo.id = new URL(animeInfo.url!).pathname.split('/')[2];
+      animeInfo.id = new URL(id).pathname.split('/')[2];
       animeInfo.title = $(
         'section.content_left > div.main_body > div:nth-child(2) > div.anime_info_body_bg > h1'
       )
@@ -140,7 +140,8 @@ class Gogoanime extends AnimeParser {
       const alias = $('#alias_anime').attr('value');
 
       const html = await this.client.get(
-        `${this.ajaxUrl
+        `${
+          this.ajaxUrl
         }/load-list-episode?ep_start=${ep_start}&ep_end=${ep_end}&id=${movie_id}&default_ep=${0}&alias=${alias}`
       );
       const $$ = load(html.data);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes an issue causing the ID returned in the info response to always be: _gogoanimehd.io_


**Summary**

Currently, the ID in the info response is always the same.  This is caused by the following lines, where we initially set the ID to the URL, and then repeat it, making it appear twice. The result of this was only used for extracting the ID, and was then overwritten.
https://github.com/consumet/consumet.ts/blob/56f2f6b519240a001330493b6d19649f97ee74a1/src/providers/anime/gogoanime.ts#L74-L88
The fix is to simply use said ID(now URL) when extracting the ID, making sure that we can still accept URLs as input. 

