### PR TITLE
fix: Zoro subOrDub fix with hasSub and hasDub add

### DIFF
--- a/src/providers/anime/zoro.ts
+++ b/src/providers/anime/zoro.ts
@@ -115,15 +115,19 @@ class Zoro extends AnimeParser {
       info.type = $('span.item').last().prev().prev().text().toUpperCase() as MediaFormat;
       info.url = `${this.baseUrl}/${id}`;
 
-      const subDub = $('div.film-stats span.item div.tick-dub')
-        .toArray()
-        .map(value => $(value).text().toLowerCase());
-      if (subDub.length > 1) {
-        info.subOrDub = SubOrSub.BOTH;
-      } else if (subDub.length > 0) {
-        info.subOrDub = subDub[0] as SubOrSub;
-      } else {
+      const hasSub: boolean = $('div.film-stats div.tick div.tick-item.tick-sub').length > 0;
+      const hasDub: boolean = $('div.film-stats div.tick div.tick-item.tick-dub').length > 0;
+
+      if (hasSub) {
         info.subOrDub = SubOrSub.SUB;
+        info.hasSub = hasSub;
+      }
+      if (hasDub) {
+        info.subOrDub = SubOrSub.DUB;
+        info.hasDub = hasDub;
+      }
+      if (hasSub && hasDub) {
+        info.subOrDub = SubOrSub.BOTH;
       }
 
       const episodesAjax = await this.client.get(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Issue**
Zoro Get Anime Info only returns ```subOrDub: "sub"``` despite of having both sub and dub available.

***Example***
https://api.consumet.org/anime/zoro/info?id=spy-x-family-17977 returns ```subOrDub: "sub"``` but this has both sub and dub available.

**What kind of change does this PR introduce?**
Fixed subOrDub also updated the hasSub and hasDub attributes.

