### PR TITLE
Update npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,6 +29,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run build
+      - run: npm run version patch
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
**UPDATE npm-publish.yml**

**ISSUE**: In actions of npm-publish.yml , publish-npm was not running correctly (completely)

**ERROR MSG** : You cannot publish over the previously published versions: 1.5.2 

**FIX** (at least I think it is) : added line npm version patch, which will update the version and then publish

Was trying to work with FlixHq , Goku but got error while fetching Sources , so I checked it was the raw keys file on github from where you fetched was deleted ```https://raw.githubusercontent.com/enimax-anime/key/e4/key.txt```, so I checked the issues there was a fix , but it wasn't updated on NPM ( reason I got error ), So I checked and there was error during publishing the package (issue being same version was pushed ).

 At least I think this is the issue and the fix, correct me if I'm wrong.