### PR TITLE
fix: change baseUrl in gogo anime provider

### DIFF
--- a/src/providers/anime/gogoanime.ts
+++ b/src/providers/anime/gogoanime.ts
@@ -20,7 +20,7 @@ import { GogoCDN, StreamSB } from '../../extractors';
 
 class Gogoanime extends AnimeParser {
   override readonly name = 'Gogoanime';
-  protected override baseUrl = 'https://gogoanimehd.io';
+  protected override baseUrl = 'https://anitaku.to/;
   protected override logo =
     'https://play-lh.googleusercontent.com/MaGEiAEhNHAJXcXKzqTNgxqRmhuKB1rCUgb15UrN_mWUNRnLpO5T1qja64oRasO7mn0';
   protected override classPath = 'ANIME.Gogoanime';

--- a/src/providers/anime/gogoanime.ts
+++ b/src/providers/anime/gogoanime.ts
@@ -20,7 +20,7 @@ import { GogoCDN, StreamSB } from '../../extractors';
 
 class Gogoanime extends AnimeParser {
   override readonly name = 'Gogoanime';
-  protected override baseUrl = 'https://anitaku.to/;
+  protected override baseUrl = 'https://anitaku.to;
   protected override logo =
     'https://play-lh.googleusercontent.com/MaGEiAEhNHAJXcXKzqTNgxqRmhuKB1rCUgb15UrN_mWUNRnLpO5T1qja64oRasO7mn0';
   protected override classPath = 'ANIME.Gogoanime';


### PR DESCRIPTION
PR type: 
Bug Fix

Changes:
Change base URL in gogo anime provider

Motivation:
gogo anime has rebranded itself into anitaku.to. consumet gogo provider throwing 404 everytime because of this


