### PR TITLE
Fix title scrape in GogoAnime search()

### DIFF
--- a/src/providers/anime/gogoanime.ts
+++ b/src/providers/anime/gogoanime.ts
@@ -68,7 +68,7 @@ class Gogoanime extends AnimeParser {
       $('div.last_episodes > ul > li').each((i, el) => {
         searchResult.results.push({
           id: $(el).find('p.name > a').attr('href')?.split('/')[2]!,
-          title: $(el).find('p.name > a').attr('title')!,
+          title: $(el).find('p.name > a').text(),
           url: `${this.baseUrl}/${$(el).find('p.name > a').attr('href')}`,
           image: $(el).find('div > a > img').attr('src'),
           releaseDate: $(el).find('p.released').text().trim(),


### PR DESCRIPTION
Scrape gogoanime search results' titles using .text() instead of .attr(title). 
Some title attributes are invalid, such as Oshi No Ko's, causing an empty title.

![image](https://github.com/consumet/consumet.ts/assets/53848567/ac23ee71-3f62-4dbb-b3ef-00000fbce182)
