### PR TITLE
Update fmovies.ts

### DIFF
--- a/src/providers/movies/fmovies.ts
+++ b/src/providers/movies/fmovies.ts
@@ -18,7 +18,7 @@ import { StreamTape, VizCloud } from '../../extractors';
 
 class Fmovies extends MovieParser {
   override readonly name = 'Fmovies';
-  protected override baseUrl = 'https://fmovies.to';
+  protected override baseUrl = 'https://fmovies24.to';
   protected override logo = 'https://s1.bunnycdn.ru/assets/sites/fmovies/logo2.png';
   protected override classPath = 'MOVIES.Fmovies';
   override supportedTypes = new Set([TvType.MOVIE, TvType.TVSERIES]);


### PR DESCRIPTION
changed the url of fmovies to https://fmovies24.to reason Fmovies shifted from there previous url to fmovies24.to this url

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

change in base url of Fmovies

**Did you add tests for your changes?**

No

**Summary**

Fmovies website has been shifted to new url fmovies24.to this one so the baseurl must be updated to get proper results

**Other information**
