### PR TITLE
fix(gogoanime): include brackets in subOrDub filter

### DIFF
--- a/src/providers/anime/gogoanime.ts
+++ b/src/providers/anime/gogoanime.ts
@@ -72,7 +72,7 @@ class Gogoanime extends AnimeParser {
           url: `${this.baseUrl}/${$(el).find('p.name > a').attr('href')}`,
           image: $(el).find('div > a > img').attr('src'),
           releaseDate: $(el).find('p.released').text().trim(),
-          subOrDub: $(el).find('p.name > a').text().toLowerCase().includes('dub')
+          subOrDub: $(el).find('p.name > a').text().toLowerCase().includes('(dub)')
             ? SubOrSub.DUB
             : SubOrSub.SUB,
         });


### PR DESCRIPTION
Change `.includes('dub')` to `.includes('(dub)')`.

A title can be falsely filtered as a dubbed show. E.g. "Dubu Wangu".