### PR TITLE
Update Kitsu GraphQL and Media URLs to New Domain

### DIFF
--- a/dist/providers/meta/anilist.js
+++ b/dist/providers/meta/anilist.js
@@ -31,7 +31,7 @@ class Anilist extends models_1.AnimeParser {
         this.logo = 'https://upload.wikimedia.org/wikipedia/commons/6/61/AniList_logo.svg';
         this.classPath = 'META.Anilist';
         this.anilistGraphqlUrl = 'https://graphql.anilist.co';
-        this.kitsuGraphqlUrl = 'https://kitsu.io/api/graphql';
+        this.kitsuGraphqlUrl = 'https://kitsu.app/api/graphql';
         this.malSyncUrl = 'https://api.malsync.moe';
         this.anifyUrl = utils_2.ANIFY_URL;
         /**

--- a/dist/providers/meta/mal.js
+++ b/dist/providers/meta/mal.js
@@ -25,7 +25,7 @@ class Myanimelist extends models_1.AnimeParser {
         this.logo = 'https://en.wikipedia.org/wiki/MyAnimeList#/media/File:MyAnimeList.png';
         this.classPath = 'META.Myanimelist';
         this.anilistGraphqlUrl = 'https://graphql.anilist.co';
-        this.kitsuGraphqlUrl = 'https://kitsu.io/api/graphql';
+        this.kitsuGraphqlUrl = 'https://kitsu.app/api/graphql';
         this.malSyncUrl = 'https://api.malsync.moe';
         this.anifyUrl = utils_2.ANIFY_URL;
         this.search = async (query, page = 1) => {

--- a/docs/providers/anilist.md
+++ b/docs/providers/anilist.md
@@ -265,7 +265,7 @@ output:
     {
       id: 'youkoso-jitsuryoku-shijou-shugi-no-kyoushitsu-e-tv-episode-12',
       title: 'What is evil? Whatever springs from weakness.',
-      image: 'https://media.kitsu.io/episodes/thumbnails/228542/original.jpg',
+      image: 'https://media.kitsu.app/episodes/thumbnails/228542/original.jpg',
       number: 12,
       description: "Melancholy, unmotivated Ayanokoji Kiyotaka attends his first day at Tokyo Metropoiltan Advanced Nuturing High School, ...",
       url: '...'

--- a/src/providers/meta/anilist.ts
+++ b/src/providers/meta/anilist.ts
@@ -55,7 +55,7 @@ class Anilist extends AnimeParser {
   protected override classPath = 'META.Anilist';
 
   private readonly anilistGraphqlUrl = 'https://graphql.anilist.co';
-  private readonly kitsuGraphqlUrl = 'https://kitsu.io/api/graphql';
+  private readonly kitsuGraphqlUrl = 'https://kitsu.app/api/graphql';
   private readonly malSyncUrl = 'https://api.malsync.moe';
   private readonly anifyUrl = ANIFY_URL;
   provider: AnimeParser;

--- a/src/providers/meta/mal.ts
+++ b/src/providers/meta/mal.ts
@@ -27,7 +27,7 @@ class Myanimelist extends AnimeParser {
   protected override classPath = 'META.Myanimelist';
 
   private readonly anilistGraphqlUrl = 'https://graphql.anilist.co';
-  private readonly kitsuGraphqlUrl = 'https://kitsu.io/api/graphql';
+  private readonly kitsuGraphqlUrl = 'https://kitsu.app/api/graphql';
   private readonly malSyncUrl = 'https://api.malsync.moe';
   private readonly anifyUrl = ANIFY_URL;
   provider: AnimeParser;


### PR DESCRIPTION
- Updated Kitsu GraphQL and media URLs from `kitsu.io` to `kitsu.app`.
- Fixes `404` errors caused by Kitsu's recent domain and CDN switch.
- Affected files: `anilist.js`, `mal.js`, `anilist.ts`, `mal.ts`, and docs.

---

**What kind of change does this PR introduce?**

This PR is a bugfix.

**Did you add tests for your changes?**

No new tests were added since this is a straightforward URL update. The existing tests should cover the relevant functionality.

**If relevant, did you update the documentation?**

Yes, the documentation has been updated to reflect the new Kitsu URLs.

**Summary**

This PR resolves an issue where Kitsu images were returning `404` errors due to their recent domain and CDN change from `kitsu.io` to `kitsu.app`. By updating the URLs, this ensures that all Kitsu-based features work smoothly without any disruption.

**Other information**

This update is essential for keeping everything running as expected. A quick review and merge would be appreciated to avoid further issues. Thanks!