### PR TITLE
fix(gogoanime): Removed trailing forward slash in baseUrl

### DIFF
--- a/src/providers/anime/gogoanime.ts
+++ b/src/providers/anime/gogoanime.ts
@@ -20,7 +20,7 @@ import { GogoCDN, Mp4Upload, StreamSB, StreamWish } from '../../extractors';
 
 class Gogoanime extends AnimeParser {
   override readonly name = 'Gogoanime';
-  protected override baseUrl = 'https://anitaku.bz/';
+  protected override baseUrl = 'https://anitaku.bz'; // Do not include a trailing forward slash.
   protected override logo =
     'https://play-lh.googleusercontent.com/MaGEiAEhNHAJXcXKzqTNgxqRmhuKB1rCUgb15UrN_mWUNRnLpO5T1qja64oRasO7mn0';
   protected override classPath = 'ANIME.Gogoanime';


### PR DESCRIPTION
This was a breaking change before, causing URL variables to have double forward slashes after `baseUrl` and breaking usage of `.split('/')[x]`.
